### PR TITLE
fix: Altera campo de status do cliente para seletor

### DIFF
--- a/src/components/cnd/CNDMonitoramento.tsx
+++ b/src/components/cnd/CNDMonitoramento.tsx
@@ -299,7 +299,11 @@ export const CNDMonitoramento: React.FC = () => {
                           </div>
                         </td>
                         <td className="p-4"><Badge variant="outline">{cliente.cnpj}</Badge></td>
-                        <td className="p-4"><Badge variant={cliente.statusCliente.toLowerCase() === 'ativo' ? 'default' : 'secondary'}>{cliente.statusCliente}</Badge></td>
+                        <td className="p-4">
+                          <Badge variant={cliente.statusCliente.toLowerCase() === 'ativo' ? 'default' : 'secondary'}>
+                            {cliente.statusCliente.charAt(0).toUpperCase() + cliente.statusCliente.slice(1)}
+                          </Badge>
+                        </td>
                         <td className="p-4">
                           <div className="flex items-center space-x-2">
                             {cliente.nacional && <Badge variant="outline" className="flex items-center"><CheckCircle className="w-3 h-3 mr-1 text-green-500"/>N</Badge>}

--- a/src/components/cnd/ClienteFormModal.tsx
+++ b/src/components/cnd/ClienteFormModal.tsx
@@ -185,7 +185,11 @@ export const ClienteFormModal: React.FC<ClienteFormModalProps> = ({
             </div>
             <div className="space-y-2">
               <Label htmlFor="statusCliente" className="text-primary font-medium">Status do Cliente *</Label>
-              <Input id="statusCliente" value={formData.statusCliente} onChange={(e) => handleInputChange('statusCliente', e.target.value)} placeholder="ativo" className={errors.statusCliente ? 'border-destructive' : ''} disabled={isLoading} />
+              <select id="statusCliente" value={formData.statusCliente} onChange={(e) => handleInputChange('statusCliente', e.target.value)} className={`w-full p-2 border rounded ${errors.statusCliente ? 'border-destructive' : 'border-input'}`} disabled={isLoading}>
+                <option value="ativo">Ativo</option>
+                <option value="inativo">Inativo</option>
+                <option value="pendente">Pendente</option>
+              </select>
               {errors.statusCliente && <span className="text-xs text-destructive">{errors.statusCliente}</span>}
             </div>
           </div>


### PR DESCRIPTION
- Substitui o campo de texto de status do cliente por um seletor com as opções 'Ativo', 'Inativo' e 'Pendente' no formulário de cliente.
- Padroniza a exibição do status na lista de clientes para ter a primeira letra maiúscula.