### PR TITLE
Fix: Passa o id da empresa na operação PUT

### DIFF
--- a/src/components/cnd/ClienteFormModal.tsx
+++ b/src/components/cnd/ClienteFormModal.tsx
@@ -121,23 +121,15 @@ export const ClienteFormModal: React.FC<ClienteFormModalProps> = ({
     }
 
     const clienteParaEnviar = {
-      cnpj: formData.empresa.cnpj,
-      periodicidade: formData.periodicidade,
-      statusCliente: formData.statusCliente,
-      nacional: formData.nacional,
-      municipal: formData.municipal,
-      estadual: formData.estadual,
+      ...formData,
       empresa: {
-        idEmpresa: cliente && cliente.empresa ? cliente.empresa.idEmpresa : lastEmpresaId + 1,
-        nomeEmpresa: formData.empresa.nomeEmpresa
-      }
+        ...formData.empresa,
+        idEmpresa: cliente ? cliente.empresa.idEmpresa : undefined,
+      },
     };
 
     try {
       await onSubmit(clienteParaEnviar);
-      if (!cliente) {
-        setLastEmpresaId(lastEmpresaId + 1);
-      }
       onClose();
     } catch (error) {
       console.error('Error submitting form:', error);

--- a/src/services/clienteService.ts
+++ b/src/services/clienteService.ts
@@ -48,8 +48,11 @@ class ClienteService {
   }
 
   // PUT /clientes/{idEmpresa} - Update existing cliente
-  async updateCliente(idEmpresa: string, cliente: UpdateClienteDto): Promise<Cliente> {
-    return this.fetchWithError(`${BASE_URL}/clientes/${idEmpresa}`, {
+  async updateCliente(cliente: UpdateClienteDto): Promise<Cliente> {
+    if (!cliente.empresa?.idEmpresa) {
+      throw new Error("idEmpresa is required for updating a cliente.");
+    }
+    return this.fetchWithError(`${BASE_URL}/clientes/${cliente.empresa.idEmpresa}`, {
       method: 'PUT',
       body: JSON.stringify(cliente),
     });


### PR DESCRIPTION
- Modifica o `clienteService` para obter o `idEmpresa` do corpo da requisição em vez de um parâmetro de URL.
- Atualiza o `ClienteFormModal` para passar o `idEmpresa` corretamente no corpo da requisição ao atualizar um cliente.